### PR TITLE
Ajuste no README.md e  Inclusao da pasta jsonlogs no .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ Thumbs.db
 
 # Pastas/arquivos locais
 cucumber-report.html
+jsonlogs
 jsonlogs/log.json
 jsonlogs/messages.ndjson
 cypress.env.json

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ https://github.com/user-attachments/assets/b9827fd0-0e71-4d36-af0d-fc38f0699fdd
 - Para acionar os testes em modo headless e cosntruir o relatório em ambiente Windowns, insira o arquivo `cucumber-json-formatter.exe` e execute no diretório do projeto:
     - `npm run run`
     - Para maiores detalhes, consutar: [`json-formatter`](https://github.com/cucumber/json-formatter) 
-- Pronto, o projeto será executado em sua máquina e construirá o relatório. �
+- Pronto, o projeto será executado em sua máquina e construirá o relatório.
 
 ### 🪧 Políticas de Testes
 ---
@@ -170,5 +170,9 @@ https://github.com/user-attachments/assets/b9827fd0-0e71-4d36-af0d-fc38f0699fdd
 > O relatório não é carregado no ambiente do git, sendo necessário baaixar para suaa máquina e abrir em um browser.
 
 # Relatório da execução
+> [!IMPORTANT]
+> Vídeo demonstrativo do relatório:
 
-Para acessar o relatório, clique [aqui](report/index.html).
+https://github.com/user-attachments/assets/f5d08f2f-76bc-4a77-ae54-ce96c31c579e
+
+


### PR DESCRIPTION
### Ajuste do vídeo demonstrativo de navegação no relatório para o README.md e inclusão da pasta jsonlogs no .gitignore

#### Contexto
Este PR ajusta o vídeo demonstrativo de navegação no relatório no `README.md` e inclui a pasta `jsonlogs` no `.gitignore`. Essas mudanças visam melhorar a documentação do projeto e garantir que arquivos temporários e desnecessários não sejam incluídos no controle de versão.

#### Mudanças Principais
- **README.md**:
  - Inclusão de um vídeo demonstrativo de navegação no relatório para fornecer uma visão clara das funcionalidades e da navegação.
- **.gitignore**:
  - Adição de regra para ignorar a pasta `jsonlogs` para garantir que logs temporários não sejam incluídos no controle de versão.

#### Como Testar
1. Abra o `README.md` e verifique se o vídeo demonstrativo está funcionando corretamente.
2. Confirme que a pasta `jsonlogs` não está incluída no controle de versão verificando o status do Git (`git status`).

#### Exemplo de `.gitignore`
Adicione a seguinte linha ao arquivo `.gitignore` para ignorar a pasta de logs JSON:
```gitignore
/jsonlogs

```
#### Screenshots
1. Não se Aplica

#### Referências
- Não se Aplica

#### Checklist
- [x] Testes escritos e aprovados
- [x] Documentação atualizada
- [x] Revisão pelo time de QA