### PR TITLE
Relatório da execução: Inclusão do comando para gerar o report

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,9 +169,9 @@ https://github.com/user-attachments/assets/b9827fd0-0e71-4d36-af0d-fc38f0699fdd
 - ##### Ao fim de cada sprint, todos os teste são executados e um relatório é construído para auxiliar na interpretação da sanidade do projeto.
 > O relatório não é carregado no ambiente do git, sendo necessário baaixar para suaa máquina e abrir em um browser.
 
-# Relatório da execução
+### Vídeo demonstrativo do Relatório da execução
 > [!IMPORTANT]
-> Vídeo demonstrativo do relatório:
+> Para gerar o reporte é nescessário execcutar o seguinte comando no terminal: `node cucumber-html-report.mjs`
 
 https://github.com/user-attachments/assets/f5d08f2f-76bc-4a77-ae54-ce96c31c579e
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ https://github.com/user-attachments/assets/b9827fd0-0e71-4d36-af0d-fc38f0699fdd
 
 ### Vídeo demonstrativo do Relatório da execução
 > [!IMPORTANT]
-> Para gerar o reporte é nescessário execcutar o seguinte comando no terminal: `node cucumber-html-report.mjs`
+> Para gerar o report é nescessário execcutar o seguinte comando no terminal: `node cucumber-html-report.mjs`
 
 https://github.com/user-attachments/assets/f5d08f2f-76bc-4a77-ae54-ce96c31c579e
 


### PR DESCRIPTION
### Relatório da execução: Inclusão do comando para gerar o report

#### Contexto
Este PR inclui o comando necessário para gerar o relatório de execução dos testes.

#### Mudanças Principais
- **Comando de Geração de Relatórios**:
  - Inclusão do comando para gerar o relatório de execução dos testes.

#### Como Testar
1. Execute o comando `node cucumber-html-report.mjs` no terminal e verifique se o relatório é gerado na pasta `/reports`.

#### Screenshots
1. Não se Aplica

#### Referências
- Issue: Não se Aplica
- Documento de Especificação: Não se Aplica

#### Checklist
- [x] Testes escritos e aprovados
- [x] Documentação atualizada
- [x] Revisão pelo time de QA
