### PR TITLE
Implementa schema para verificar estrutura da lista do Modelo Pet

### DIFF
--- a/cypress/e2e/features/structural/petSchema.feature
+++ b/cypress/e2e/features/structural/petSchema.feature
@@ -1,0 +1,7 @@
+Feature: Verificar contrato do Modelo Pet
+
+    @regression @back @structural
+    Scenario: Assegurar que o contrato terá a estrutura válida para o modelo Pet
+        Given que tem acesso à API Swagger Petstore para validar a estrutura
+        When realizar a requisição passando o status válido
+        Then retornará informando que o contrato para o Modelo Pet está dentro do esperado

--- a/cypress/e2e/step_test_definitions/structural/petSchema.spec.js
+++ b/cypress/e2e/step_test_definitions/structural/petSchema.spec.js
@@ -1,0 +1,18 @@
+
+/// <reference types="cypress" />
+
+import { Given, Then, When } from "@badeball/cypress-cucumber-preprocessor"
+import { requestGetPetStandard } from "@requests/Petstore/standardFlow/pet/request_get_pet_findByStatus_standard";
+import { definitionsSchemaPet } from '@schema/petSchema';
+
+Given("que tem acesso à API Swagger Petstore para validar a estrutura", () => { })
+
+Then("realizar a requisição passando o status válido", () => { })
+
+When("retornará informando que o contrato para o Modelo Pet está dentro do esperado", () => {
+    const validStatuses = 'sold';
+
+    requestGetPetStandard.getcheckPetStatusFilter(validStatuses).then((getDataResponse) => {
+        expect(getDataResponse.body).to.be.jsonSchema(definitionsSchemaPet)
+    });
+})

--- a/cypress/support/structural/petSchema.js
+++ b/cypress/support/structural/petSchema.js
@@ -1,0 +1,63 @@
+export const definitionsSchemaPet = {
+    title: "Validar estrutura do Pet",
+    type: "array",
+    required: ['id', 'name', 'photoUrls', 'status'],  // Campos obrigatórios
+
+    properties: {
+        id: {
+            type: 'integer',
+            format: 'int64',
+        },
+        category: {
+            type: 'object',
+            properties: {
+                id: {
+                    type: 'integer',
+                    format: 'int64',
+                },
+                name: {
+                    type: 'string',
+                },
+            }
+        },
+        name: {
+            type: 'string',
+            example: 'doggie',
+        },
+        photoUrls: {
+            type: 'array',
+            items: {
+                type: 'string',
+                xml: {
+                    name: "photoUrl"
+                }
+            },
+            xml: {
+                wrapped: true
+            }
+        },
+        tags: {
+            type: 'array',
+            items: {
+                type: 'object',
+                properties: {
+                    id: {
+                        type: 'integer',
+                        format: 'int64',
+                    },
+                    name: {
+                        type: 'string',
+                    }
+                }
+            },
+            xml: {
+                wrapped: true
+            }
+        },
+        status: {
+            type: 'string',
+            description: 'pet status in the store',
+            enum: ['available', 'pending', 'sold']
+        }
+    }
+};

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -19,6 +19,9 @@
             ], 
             "@path_fixtures/*": [
                 "cypress/support/utils/paths.json"
+            ], 
+            "@schema/*": [
+                "cypress/support/structural/*"
             ]
         }
     }


### PR DESCRIPTION
### Adiciona teste de schema para verificar estrutura da lista do Modelo Pet
 
#### Contexto
Este PR adiciona um teste para validar o contrato do esquema do modelo Pet. O objetivo é garantir que a resposta da API esteja em conformidade com o esquema definido, validando a estrutura e os tipos de dados dos objetos Pet. Este teste ajuda a assegurar que as respostas da API atendam aos requisitos especificados e facilita a detecção precoce de problemas de compatibilidade com o contrato da API.
 
#### Mudanças Principais
  - Implementação do esquema de validação JSON para o modelo Pet.
 
#### Como Testar
1. Executar o arquivo `cypress/e2e/features/structural/petSchema.feature`
 
#### Screenshots

![petSchema](https://github.com/user-attachments/assets/829f58d7-c2f9-4a64-ac2e-7ddcf2e869e2)

#### Referências
- TestLink: ID-111 (ID do cenário no testlink)
- Jira: ID-AAAA (ID do card no Jira)

#### Checklist
- [x] Testes escritos e passando
- [x] Documentação atualizada (caso se aplique)
- [x] Screenshots anexado do teste aprovado
- [x] Revisão pelo time de QA